### PR TITLE
fixing uncapitalized ioc macro

### DIFF
--- a/pcds_motionApp/srcDisplay/mmn-emb-1-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-1-axis.edl
@@ -184,7 +184,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-emb-2-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-2-axis.edl
@@ -214,7 +214,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-emb-3-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-3-axis.edl
@@ -243,7 +243,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-emb-4-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-4-axis.edl
@@ -272,7 +272,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-emb-5-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-5-axis.edl
@@ -301,7 +301,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-emb-6-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-6-axis.edl
@@ -330,7 +330,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-emb-8-axis.edl
+++ b/pcds_motionApp/srcDisplay/mmn-emb-8-axis.edl
@@ -388,7 +388,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/mmn-motor-control.edl
+++ b/pcds_motionApp/srcDisplay/mmn-motor-control.edl
@@ -1333,7 +1333,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-control.edl
+++ b/pcds_motionApp/srcDisplay/motor-control.edl
@@ -2700,7 +2700,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-1-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-1-axis.edl
@@ -184,7 +184,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-2-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-2-axis.edl
@@ -214,7 +214,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-3-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-3-axis.edl
@@ -243,7 +243,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-4-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-4-axis.edl
@@ -272,7 +272,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-5-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-5-axis.edl
@@ -301,7 +301,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-6-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-6-axis.edl
@@ -330,7 +330,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1

--- a/pcds_motionApp/srcDisplay/motor-emb-8-axis.edl
+++ b/pcds_motionApp/srcDisplay/motor-emb-8-axis.edl
@@ -388,7 +388,7 @@ setPosition {
   0 "parentWindow"
 }
 symbols {
-  0 "ioc=$(IOC)"
+  0 "IOC=$(IOC)"
 }
 replaceSymbols {
   0 1


### PR DESCRIPTION
Several edm screens were trying trying to open ioc_soft.edl by passing in the macro ioc=$(IOC), but ioc_soft.edl expects the macro IOC to be set (all lowercase vs all uppercase). This made the screen nonfunctional since it didn't have access to the ioc macro needed for the ioc pvs.

Before:
![image](https://github.com/user-attachments/assets/6c6be81f-68b6-4f70-a421-d8591f422270)

After: (the missing heartbeat pvs are because the pvs were removed from iocAdmin but not the screen)
![image](https://github.com/user-attachments/assets/89de1916-b264-42d6-96b3-933494618a3a)

